### PR TITLE
Re-enable provenance

### DIFF
--- a/.changeset/beige-phones-thank.md
+++ b/.changeset/beige-phones-thank.md
@@ -1,0 +1,5 @@
+---
+"@changesets/ghcommit": patch
+---
+
+Re-enable provenance when publishing to NPM

--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-and-publish:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+provenance=true
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Re-enable provenance when publishing to NPM (disabled in #28)

See docs: https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions