### PR TITLE
Update changesets/action and use API to commit

### DIFF
--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -33,9 +33,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Run Changeset Workflow
-        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
+        uses: changesets/action@746c25e23caa47dceb6a48ee85b4cbc5a9f5f293 # v1.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           publish: pnpm changeset publish
+          commitMode: github-api


### PR DESCRIPTION
Make use of the new `commitMode` option to use the GitHub API to commit changes to this repo.

No changelog required as this doesn't affect the published package, only CI workflows.