### PR TITLE
Explicitly throw errors when executable files are found

### DIFF
--- a/.changeset/lazy-icons-cheer.md
+++ b/.changeset/lazy-icons-cheer.md
@@ -1,0 +1,5 @@
+---
+"@changesets/ghcommit": minor
+---
+
+Throw an error when executable files are encountered

--- a/src/git.ts
+++ b/src/git.ts
@@ -68,6 +68,11 @@ export const commitChangesFromRepo = async ({
           `Unexpected symlink at ${filepath}, GitHub API only supports files and directories. You may need to add this file to .gitignore`,
         );
       }
+      if ((await workdir?.mode()) === FILE_MODES.executableFile) {
+        throw new Error(
+          `Unexpected executable file at ${filepath}, GitHub API only supports non-executable files and directories. You may need to add this file to .gitignore`,
+        );
+      }
       const prevOid = await commit?.oid();
       const currentOid = await workdir?.oid();
       // Don't include files that haven't changed, and exist in both trees


### PR DESCRIPTION
Executable files will be committed incorrectly (without appropriate flags / modes), so we need to make it explicit that they're not supported, but can be added to `.gitignore` files.