### PR TITLE
Remove any use of process.cwd(), and clean up directory options across functions

### DIFF
--- a/.changeset/blue-carpets-jam.md
+++ b/.changeset/blue-carpets-jam.md
@@ -1,0 +1,21 @@
+---
+"@changesets/ghcommit": major
+---
+
+Refactor & clean up options for multiple functions
+
+- For `commitFilesFromDirectory`:
+  - Rename `workingDirectory` to `cwd` for consistency across repos,
+    and utils like `exec`
+  - Make `cwd` a required argument
+- For `commitChangesFromRepo`:
+  - Merge `repoDirectory` and `addFromDirectory` into a single required argument
+    `cwd`. This folder will now both be used to filter which files are added,
+    and to find the root of the repository.
+  - Introduce `recursivelyFindRoot` option (default: `true`),
+    to optionally search for the root of the repository,
+    by checking for existence of `.git` directory in parent directories,
+    starting from `cwd`.
+
+This effectively removes all usage of process.cwd() within the package,
+instead requiring all usage to be very explicit with specifying paths.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ In addition to `CommitFilesBasedArgs`, this function has the following arguments
 ```ts
 {
   /**
+   * The directory used to find the repository root,
+   * and search for changed files to commit.
+   *
+   * Any files that have been changed outside of this directory will be ignored.
+   */
+  cwd: string;
+  /**
    * The base commit to build your changes on-top of
    *
    * @default HEAD
@@ -91,21 +98,13 @@ In addition to `CommitFilesBasedArgs`, this function has the following arguments
     commit: string;
   };
   /**
-   * The root of the repository.
+   * Don't require {@link cwd} to be the root of the repository,
+   * and use it as a starting point to recursively search for the `.git`
+   * directory in parent directories.
    *
-   * When unspecified, the root of the repository will be found by recursively
-   * searching for the `.git` directory from the current working directory.
+   * @default true
    */
-  repoDirectory?: string;
-  /**
-   * The starting directory to recurse from when detecting changed files.
-   *
-   * Useful for monorepos where you want to add files from a specific directory only.
-   *
-   * Defaults to resolved value of {@link repoDirectory},
-   * which will add all changed files in the repository.
-   */
-  addFromDirectory?: string;
+  recursivelyFindRoot?: boolean;
   /**
    * An optional function that can be used to filter which files are included
    * in the commit. True should be returned for files that should be included.
@@ -131,6 +130,7 @@ await commitChangesFromRepo({
   ...context.repo,
   branch: "new-branch-to-create",
   message: "[chore] do something",
+  cwd: process.cwd(),
 });
 
 // Commit & push the files from a specific directory
@@ -141,7 +141,7 @@ await commitChangesFromRepo({
   repository: "my-repo",
   branch: "another-new-branch-to-create",
   message: "[chore] do something else\n\nsome more details",
-  repoDirectory: "/tmp/some-repo",
+  cwd: "/tmp/some-repo",
 });
 
 // Commit & push the files from the current directory,
@@ -154,6 +154,7 @@ await commitChangesFromRepo({
     headline: "[chore] do something else",
     body: "some more details",
   },
+  cwd: process.cwd(),
   base: {
     // This will be the original sha from the workflow run,
     // even if we've made commits locally
@@ -178,7 +179,7 @@ In addition to `CommitFilesBasedArgs`, this function has the following arguments
    * The directory to consider the root of the repository when calculating
    * file paths
    */
-  workingDirectory?: string;
+  cwd: string;
   /**
    * The file paths, relative to {@link workingDirectory},
    * to add or delete from the branch on GitHub.
@@ -210,7 +211,7 @@ await commitFilesFromDirectory({
   base: {
     branch: "main",
   },
-  workingDirectory: "foo/bar",
+  cwd: "foo/bar",
   fileChanges: {
     additions: ["package-lock.json", "package.json"],
   },
@@ -226,7 +227,7 @@ await commitFilesFromDirectory({
   base: {
     tag: "v1.0.0",
   },
-  workingDirectory: "some-dir",
+  cwd: "some-dir",
   fileChanges: {
     additions: ["index.html"],
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "eslint-plugin-jest": "^28.6.0",
     "eslint-plugin-only-warn": "^1.1.0",
     "jest": "^29.7.0",
-    "mock-cwd": "^1.0.0",
     "pino": "^9.3.2",
     "pino-pretty": "^11.2.2",
     "prettier": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
-      mock-cwd:
-        specifier: ^1.0.0
-        version: 1.0.0
       pino:
         specifier: ^9.3.2
         version: 9.3.2
@@ -2841,9 +2838,6 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mock-cwd@1.0.0:
-    resolution: {integrity: sha512-g+hi96nCWcS4HC5lA6VtL9SHmPywPkXSX6S4DTctmGoi6H8uYVa7lK/h22s8rMQie8b+b1+ywnPC61iXF6mriQ==}
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -3136,13 +3130,6 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
-  randomstring@1.3.1:
-    resolution: {integrity: sha512-lgXZa80MUkjWdE7g2+PZ1xDLzc7/RokXVEQOv5NN2UOTChW1I8A9gha5a9xYBOqgaSoI6uJikDmCU8PyRdArRQ==}
-    hasBin: true
-
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -3427,10 +3414,6 @@ packages:
 
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
-
-  temp-dir@2.0.0:
-    resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
-    engines: {node: '>=8'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -7312,11 +7295,6 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mock-cwd@1.0.0:
-    dependencies:
-      randomstring: 1.3.1
-      temp-dir: 2.0.0
-
   mri@1.2.0: {}
 
   ms@2.1.2: {}
@@ -7593,14 +7571,6 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  randomstring@1.3.1:
-    dependencies:
-      randombytes: 2.1.0
 
   react-is@18.3.1: {}
 
@@ -7890,8 +7860,6 @@ snapshots:
   swap-case@2.0.2:
     dependencies:
       tslib: 2.6.3
-
-  temp-dir@2.0.0: {}
 
   term-size@2.2.1: {}
 

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -8,7 +8,7 @@ import {
 } from "./interface.js";
 
 export const commitFilesFromDirectory = async ({
-  workingDirectory = process.cwd(),
+  cwd,
   fileChanges,
   ...otherArgs
 }: CommitFilesFromDirectoryArgs): Promise<CommitFilesResult> => {
@@ -16,7 +16,7 @@ export const commitFilesFromDirectory = async ({
     (fileChanges.additions || []).map(async (p) => {
       return {
         path: p,
-        contents: await fs.readFile(path.join(workingDirectory, p)),
+        contents: await fs.readFile(path.join(cwd, p)),
       };
     }),
   );

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -72,13 +72,13 @@ export interface CommitFilesFromDirectoryArgs
    * The directory to consider the root of the repository when calculating
    * file paths
    */
-  workingDirectory?: string;
+  cwd: string;
   /**
-   * The file paths, relative to {@link workingDirectory},
+   * The file paths, relative to {@link cwd},
    * to add or delete from the branch on GitHub.
    */
   fileChanges: {
-    /** File paths, relative to {@link workingDirectory}, to remove from the repo. */
+    /** File paths, relative to {@link cwd}, to remove from the repo. */
     additions?: string[];
     /** File paths, relative to the repository root, to remove from the repo. */
     deletions?: string[];
@@ -86,6 +86,13 @@ export interface CommitFilesFromDirectoryArgs
 }
 
 export interface CommitChangesFromRepoArgs extends CommitFilesBasedArgs {
+  /**
+   * The directory used to find the repository root,
+   * and search for changed files to commit.
+   *
+   * Any files that have been changed outside of this directory will be ignored.
+   */
+  cwd: string;
   /**
    * The base commit to build your changes on-top of.
    *
@@ -105,21 +112,13 @@ export interface CommitChangesFromRepoArgs extends CommitFilesBasedArgs {
     commit: string;
   };
   /**
-   * The root of the repository.
+   * Don't require {@link cwd} to be the root of the repository,
+   * and use it as a starting point to recursively search for the `.git`
+   * directory in parent directories.
    *
-   * When unspecified, the root of the repository will be found by recursively
-   * searching for the `.git` directory from the current working directory.
+   * @default true
    */
-  repoDirectory?: string;
-  /**
-   * The starting directory to recurse from when detecting changed files.
-   *
-   * Useful for monorepos where you want to add files from a specific directory only.
-   *
-   * Defaults to resolved value of {@link repoDirectory},
-   * which will add all changed files in the repository.
-   */
-  addFromDirectory?: string;
+  recursivelyFindRoot?: boolean;
   /**
    * An optional function that can be used to filter which files are included
    * in the commit. True should be returned for files that should be included.

--- a/src/test/integration/fs.test.ts
+++ b/src/test/integration/fs.test.ts
@@ -37,7 +37,7 @@ describe("fs", () => {
           headline: "Test commit",
           body: "This is a test commit",
         },
-        workingDirectory: tmpDir,
+        cwd: tmpDir,
         fileChanges: {
           additions: ["foo.txt"],
         },

--- a/src/test/integration/node.test.ts
+++ b/src/test/integration/node.test.ts
@@ -219,7 +219,7 @@ describe("node", () => {
         ...REPO,
         branch,
         base: {
-          tag: "v0.1.0",
+          tag: "v1.4.0",
         },
         ...BASIC_FILE_CONTENTS,
       });


### PR DESCRIPTION
This PR addresses #39 by ntroducing breaking changes to how we require directories to be specified in the arguments to 2 key functions.

Full information in the `.changesets` folder, but TL;DR:

- `cwd` is now used as the directory name in both files (brings consistency with https://github.com/changesets/action)
- `cwd` is required (no default use of `process.cwd()`)
- `commitChangesFromRepo` args have been simplified to only require 1 directory

fixes #39 