### PR TITLE
Make repo required & remove deprecated arg

### DIFF
--- a/.changeset/afraid-ducks-know.md
+++ b/.changeset/afraid-ducks-know.md
@@ -1,0 +1,7 @@
+---
+"@changesets/ghcommit": major
+---
+
+Make `repo` argument required,
+and remove the `repository` argument which was deprecated
+and previously could be used in its place.

--- a/src/core.ts
+++ b/src/core.ts
@@ -49,7 +49,6 @@ export const commitFilesFromBase64 = async ({
   octokit,
   owner,
   repo,
-  repository,
   branch,
   base,
   force = false,
@@ -57,14 +56,9 @@ export const commitFilesFromBase64 = async ({
   fileChanges,
   log,
 }: CommitFilesFromBase64Args): Promise<CommitFilesResult> => {
-  const repositoryNameWithOwner = `${owner}/${repository}`;
+  const repositoryNameWithOwner = `${owner}/${repo}`;
   const baseRef = getBaseRef(base);
   const targetRef = `refs/heads/${branch}`;
-  repo = repo ?? repository;
-
-  if (!repo) {
-    throw new Error(`Argument 'repo' must be provided`);
-  }
 
   log?.debug(`Getting repo info ${repositoryNameWithOwner}`);
   const info = await getRepositoryMetadata(octokit, {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -24,9 +24,7 @@ export type GitBase =
 export interface CommitFilesBasedArgs {
   octokit: GitHubClient;
   owner: string;
-  repo?: string;
-  /** @deprecated use {@link repo} instead */
-  repository?: string;
+  repo: string;
   branch: string;
   /**
    * Push the commit even if the branch exists and does not match what was


### PR DESCRIPTION
As #40 introduces a new major version, probably makes sense to remove some of the previously deprecated fields / options, and clean up some code.